### PR TITLE
Add patron account and history sections to dashboard

### DIFF
--- a/library-frontend/src/App.jsx
+++ b/library-frontend/src/App.jsx
@@ -1,10 +1,10 @@
-import AddBook from './pages/AddBook';
+import Dashboard from './pages/Dashboard';
 
 function App() {
   return (
     <div>
       <h1>Library Management System</h1>
-      <AddBook />
+      <Dashboard role="user" />
     </div>
   );
 }

--- a/library-frontend/src/App.test.js
+++ b/library-frontend/src/App.test.js
@@ -1,8 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders dashboard heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/Library Management System/i);
+  expect(headerElement).toBeInTheDocument();
+});
+
+test('shows account and history links for user role', () => {
+  render(<App />);
+  expect(screen.getAllByText(/Account/i).length).toBeGreaterThan(0);
+  expect(screen.getAllByText(/History/i).length).toBeGreaterThan(0);
 });

--- a/library-frontend/src/components/Sidebar.jsx
+++ b/library-frontend/src/components/Sidebar.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function Sidebar({ role }) {
+  const links = [{ text: 'View Books', path: '#' }];
+  if (role === 'admin') {
+    links.push({ text: 'Add Book', path: '#' });
+    links.push({ text: 'Add User', path: '#' });
+  } else {
+    links.push({ text: 'Account', path: '#' });
+    links.push({ text: 'History', path: '#' });
+  }
+
+  return (
+    <div style={{ width: '200px', background: '#f0f0f0', padding: '1rem' }}>
+      <ul style={{ listStyle: 'none', padding: 0 }}>
+        {links.map(link => (
+          <li key={link.text} style={{ marginBottom: '0.5rem' }}>
+            <a href={link.path}>{link.text}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/library-frontend/src/pages/Account.jsx
+++ b/library-frontend/src/pages/Account.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Account() {
+  return (
+    <div>
+      <h3>Account</h3>
+      <p>Your account details.</p>
+    </div>
+  );
+}

--- a/library-frontend/src/pages/Dashboard.jsx
+++ b/library-frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Sidebar from '../components/Sidebar';
+import Account from './Account';
+import History from './History';
+
+export default function Dashboard({ role = 'user' }) {
+  return (
+    <div style={{ display: 'flex' }}>
+      <Sidebar role={role} />
+      <div style={{ marginLeft: '1rem', padding: '1rem' }}>
+        <h2>Dashboard</h2>
+        <p>Welcome to your dashboard, {role}.</p>
+        {role !== 'admin' && (
+          <>
+            <Account />
+            <History />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/library-frontend/src/pages/History.jsx
+++ b/library-frontend/src/pages/History.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function History() {
+  return (
+    <div>
+      <h3>History</h3>
+      <p>Your borrowing history.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show Account and History links in the sidebar for patron users
- add simple Account and History components and render them on the dashboard
- update tests to confirm new sidebar links appear for patrons

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6899266a3070832a9e30cb3895145a8c