### PR TITLE
feat(frontend): add patron dashboard

### DIFF
--- a/library-frontend-angular/src/app/app-routing.module.ts
+++ b/library-frontend-angular/src/app/app-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { DashboardComponent } from './dashboard/dashboard.component';
+
+const routes: Routes = [
+  { path: '', component: DashboardComponent }
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule]
+})
+export class AppRoutingModule {}

--- a/library-frontend-angular/src/app/app.component.html
+++ b/library-frontend-angular/src/app/app.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/library-frontend-angular/src/app/app.component.ts
+++ b/library-frontend-angular/src/app/app.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html'
+})
+export class AppComponent {}

--- a/library-frontend-angular/src/app/app.module.ts
+++ b/library-frontend-angular/src/app/app.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatTableModule } from '@angular/material/table';
+
+import { AppComponent } from './app.component';
+import { DashboardComponent } from './dashboard/dashboard.component';
+import { AppRoutingModule } from './app-routing.module';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    DashboardComponent
+  ],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatToolbarModule,
+    MatMenuModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatTableModule,
+    AppRoutingModule
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }

--- a/library-frontend-angular/src/app/dashboard/dashboard.component.css
+++ b/library-frontend-angular/src/app/dashboard/dashboard.component.css
@@ -1,0 +1,11 @@
+.account-form {
+  padding: 16px;
+}
+
+.spacer {
+  flex: 1 1 auto;
+}
+
+.mat-form-field {
+  display: block;
+}

--- a/library-frontend-angular/src/app/dashboard/dashboard.component.html
+++ b/library-frontend-angular/src/app/dashboard/dashboard.component.html
@@ -1,0 +1,44 @@
+<mat-toolbar color="primary">
+  <span>Patron Dashboard</span>
+  <span class="spacer"></span>
+  <button mat-button [matMenuTriggerFor]="menu">Account</button>
+</mat-toolbar>
+
+<mat-menu #menu="matMenu">
+  <button mat-menu-item (click)="toggleAccountForm()">Update Info</button>
+</mat-menu>
+
+<div *ngIf="showAccountForm" class="account-form">
+  <form [formGroup]="accountForm" (ngSubmit)="save()">
+    <mat-form-field appearance="fill">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>Email</mat-label>
+      <input matInput formControlName="email" />
+    </mat-form-field>
+    <button mat-raised-button color="primary" type="submit">Save</button>
+  </form>
+</div>
+
+<h2>Loan History</h2>
+<table mat-table [dataSource]="loanHistory" class="mat-elevation-z8">
+  <ng-container matColumnDef="title">
+    <th mat-header-cell *matHeaderCellDef>Title</th>
+    <td mat-cell *matCellDef="let row">{{ row.title }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="borrowed">
+    <th mat-header-cell *matHeaderCellDef>Borrowed</th>
+    <td mat-cell *matCellDef="let row">{{ row.borrowed | date }}</td>
+  </ng-container>
+
+  <ng-container matColumnDef="returned">
+    <th mat-header-cell *matHeaderCellDef>Returned</th>
+    <td mat-cell *matCellDef="let row">{{ row.returned ? (row.returned | date) : 'Not returned' }}</td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+</table>

--- a/library-frontend-angular/src/app/dashboard/dashboard.component.ts
+++ b/library-frontend-angular/src/app/dashboard/dashboard.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { UserService, LoanRecord, User } from '../user.service';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.css']
+})
+export class DashboardComponent implements OnInit {
+  showAccountForm = false;
+  accountForm: FormGroup;
+  loanHistory: LoanRecord[] = [];
+
+  displayedColumns = ['title', 'borrowed', 'returned'];
+
+  constructor(private fb: FormBuilder, private userService: UserService) {
+    this.accountForm = this.fb.group({
+      name: '',
+      email: ''
+    });
+  }
+
+  ngOnInit(): void {
+    this.userService.user$.subscribe(user => this.accountForm.setValue(user));
+    this.loanHistory = this.userService.getLoanHistory();
+  }
+
+  toggleAccountForm(): void {
+    this.showAccountForm = !this.showAccountForm;
+  }
+
+  save(): void {
+    const user: User = this.accountForm.value;
+    this.userService.updateUser(user);
+    this.showAccountForm = false;
+  }
+}

--- a/library-frontend-angular/src/app/user.service.ts
+++ b/library-frontend-angular/src/app/user.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface User {
+  name: string;
+  email: string;
+}
+
+export interface LoanRecord {
+  title: string;
+  borrowed: Date;
+  returned: Date | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  private userSubject = new BehaviorSubject<User>({ name: 'Jane Doe', email: 'jane@example.com' });
+  user$ = this.userSubject.asObservable();
+
+  private loans: LoanRecord[] = [
+    { title: 'Moby Dick', borrowed: new Date('2024-01-10'), returned: new Date('2024-02-10') },
+    { title: '1984', borrowed: new Date('2024-03-05'), returned: null }
+  ];
+
+  getLoanHistory(): LoanRecord[] {
+    return this.loans;
+  }
+
+  updateUser(user: User): void {
+    this.userSubject.next(user);
+  }
+}

--- a/library-frontend-angular/src/index.html
+++ b/library-frontend-angular/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Library Frontend</title>
+  <base href="/" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/library-frontend-angular/src/main.ts
+++ b/library-frontend-angular/src/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/library-frontend-angular/src/styles.css
+++ b/library-frontend-angular/src/styles.css
@@ -1,0 +1,5 @@
+/* Global styles for the app */
+body {
+  margin: 0;
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+}


### PR DESCRIPTION
## Summary
- scaffold basic Angular app structure
- add patron dashboard with account info updates and loan history table

## Testing
- `npm test` *(fails: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68993d28aaa4832a8bcd876a6320f131